### PR TITLE
Changed navigationController parameter to `assign`

### DIFF
--- a/CCNNavigationController/CCNNavigationController.m
+++ b/CCNNavigationController/CCNNavigationController.m
@@ -381,7 +381,7 @@ NSString *const CCNNavigationControllerNotificationUserInfoKey = @"viewControlle
 }
 
 - (void)setNavigationController:(CCNNavigationController *)navigationController {
-    objc_setAssociatedObject(self, @selector(navigationController), navigationController, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(self, @selector(navigationController), navigationController, OBJC_ASSOCIATION_ASSIGN);
 }
 @end
 


### PR DESCRIPTION
Otherwise there is a retain cycle:
CCNNavigationController retains rootController in _viewControllers and rootController retains CCNNavigationController in navigationController property