### PR TITLE
Fix mediaTimingFunction retain policy

### DIFF
--- a/CCNNavigationController/CCNNavigationController.h
+++ b/CCNNavigationController/CCNNavigationController.h
@@ -310,6 +310,6 @@ typedef NS_ENUM(NSUInteger, CCNNavigationControllerTransitionStyle) {
 /**
  *  Property that controls the timing function that has to be used during transition.
  */
-@property (nonatomic, assign) CAMediaTimingFunction *mediaTimingFunction;
+@property (nonatomic, strong) CAMediaTimingFunction *mediaTimingFunction;
 
 @end


### PR DESCRIPTION
`CAMediaTimingFunction` is an object, so it makes sense to retain it strongly.